### PR TITLE
community: Skip unexpected 404 HTTP Error in Arxiv download

### DIFF
--- a/libs/community/langchain_community/utilities/arxiv.py
+++ b/libs/community/langchain_community/utilities/arxiv.py
@@ -2,8 +2,8 @@
 import logging
 import os
 import re
+from urllib.error import HTTPError
 from typing import Any, Dict, Iterator, List, Optional
-import urllib
 
 from langchain_core.documents import Document
 from langchain_core.pydantic_v1 import BaseModel, root_validator

--- a/libs/community/langchain_community/utilities/arxiv.py
+++ b/libs/community/langchain_community/utilities/arxiv.py
@@ -2,8 +2,8 @@
 import logging
 import os
 import re
-from urllib.error import HTTPError
 from typing import Any, Dict, Iterator, List, Optional
+from urllib.error import HTTPError
 
 from langchain_core.documents import Document
 from langchain_core.pydantic_v1 import BaseModel, root_validator
@@ -227,7 +227,7 @@ class ArxivAPIWrapper(BaseModel):
             except (FileNotFoundError, fitz.fitz.FileDataError) as f_ex:
                 logger.debug(f_ex)
                 continue
-            except urllib.error.HTTPError as f_ex:
+            except HTTPError as f_ex:
                 if f_ex.code in self.ARXIV_API_WRAPPER_ALLOWED_HTTP_ERROR_CODES:
                     logger.debug(f_ex)
                     continue

--- a/libs/community/tests/integration_tests/document_loaders/test_arxiv.py
+++ b/libs/community/tests/integration_tests/document_loaders/test_arxiv.py
@@ -1,4 +1,5 @@
 import shutil
+from http.client import HTTPMessage
 from pathlib import Path
 from typing import List, Union
 from unittest.mock import patch
@@ -66,11 +67,13 @@ def test_load_returns_full_set_of_metadata() -> None:
 def test_skip_http_error() -> None:
     """Test skipping unexpected Http 404 error of a single doc"""
     tmp_hello_pdf_path = Path(__file__).parent / "hello.pdf"
-    
+
     def first_download_fails() -> Union[HTTPError, str]:
-        if not hasattr(first_download_fails, 'firstCall'):
-            first_download_fails.firstCall = False
-            raise HTTPError(url=None, code=404, msg="Not Found", hdrs=None, fp=None)
+        if not hasattr(first_download_fails, "firstCall"):
+            first_download_fails.__setattr__("firstCall", False)
+            raise HTTPError(
+                url="", code=404, msg="Not Found", hdrs=HTTPMessage(), fp=None
+            )
         else:
             # Return temporary example pdf path
             shutil.copy(EXAMPLE_HELLO_PDF_PATH, tmp_hello_pdf_path)

--- a/libs/community/tests/integration_tests/document_loaders/test_arxiv.py
+++ b/libs/community/tests/integration_tests/document_loaders/test_arxiv.py
@@ -1,6 +1,6 @@
 import shutil
 from pathlib import Path
-from typing import List
+from typing import List, Union
 from unittest.mock import patch
 from urllib.error import HTTPError
 
@@ -66,17 +66,15 @@ def test_load_returns_full_set_of_metadata() -> None:
 def test_skip_http_error() -> None:
     """Test skipping unexpected Http 404 error of a single doc"""
     tmp_hello_pdf_path = Path(__file__).parent / "hello.pdf"
-
-    def first_download_fails():
-        if first_download_fails.firstCall:
+    
+    def first_download_fails() -> Union[HTTPError, str]:
+        if not hasattr(first_download_fails, 'firstCall'):
             first_download_fails.firstCall = False
             raise HTTPError(url=None, code=404, msg="Not Found", hdrs=None, fp=None)
         else:
             # Return temporary example pdf path
             shutil.copy(EXAMPLE_HELLO_PDF_PATH, tmp_hello_pdf_path)
             return str(tmp_hello_pdf_path.absolute())
-
-    first_download_fails.firstCall = True
 
     with patch("arxiv.Result.download_pdf") as mock_download_pdf:
         # Set up the mock to raise HTTP 404 error


### PR DESCRIPTION
### Description:
When attempting to download PDF files from arXiv, an unexpected 404 error frequently occurs. This error halts the operation, regardless of whether there are additional documents to process. As a solution, I suggest implementing a mechanism to ignore and communicate this error and continue processing the next document from the list.

Proposed Solution: To address the issue of unexpected 404 errors during PDF downloads from arXiv, I propose implementing the following solution:

- Error Handling: Implement error handling mechanisms to catch and handle 404 errors gracefully.
- Communication: Inform the user or logging system about the occurrence of the 404 error.
- Continued Processing: After encountering a 404 error, continue processing the remaining documents from the list without interruption.

This solution ensures that the application can handle unexpected errors without terminating the entire operation. It promotes resilience and robustness in the face of intermittent issues encountered during PDF downloads from arXiv.

### Issue:
https://github.com/langchain-ai/langchain/issues/20909

### Dependencies:
none
   